### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,21 +6,21 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Chronos KEYWORD1
-DateTime KEYWORD1
+Chronos	KEYWORD1
+DateTime	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-Chronos KEYWORD2
-~Chronos KEYWORD2
-writeInt KEYWORD2
-setBrightness KEYWORD2
-showTemp KEYWORD2
-showTime KEYWORD2
-setIntRollOver KEYWORD2
-getTemperature KEYWORD2
+Chronos	KEYWORD2
+~Chronos	KEYWORD2
+writeInt	KEYWORD2
+setBrightness	KEYWORD2
+showTemp	KEYWORD2
+showTime	KEYWORD2
+setIntRollOver	KEYWORD2
+getTemperature	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords